### PR TITLE
Revise table layout and remove fractal tree blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ https://prozac0401.github.io/WebSim
 - [Langton의 개미 시뮬레이터](https://prozac0401.tistory.com/35) - [source](langtons_ant_simulator/langtons_ant_simulator.html) - [설명](langtons_ant_simulator/langtons_ant_simulator.md)
 - [JavaScript QR 코드 생성기](https://prozac0401.tistory.com/53) - [source](qr_generator/qr_generator.html) - [설명](qr_generator/qr_generator.md)
 - [ulam_spiral 패턴 시각화](https://prozac0401.tistory.com/48) - [source](ulam_spiral/ulam_spiral.html) - [설명](ulam_spiral/ulam_spiral.md)
-- [프랙탈 나무 시뮬레이터](https://prozac0401.tistory.com/61) - [source](fractal_tree_simulator/fractal_tree_simulator.html) - [설명](fractal_tree_simulator/fractal_tree_simulator.md)
+- 프랙탈 나무 시뮬레이터 - [source](fractal_tree_simulator/fractal_tree_simulator.html) - [설명](fractal_tree_simulator/fractal_tree_simulator.md)

--- a/fractal_tree_simulator/fractal_tree_simulator.md
+++ b/fractal_tree_simulator/fractal_tree_simulator.md
@@ -1,5 +1,4 @@
 # Fractal Tree Simulator
-[블로그 글]
-https://prozac0401.tistory.com/61
+블로그 글은 준비 중입니다.
 
 간단한 L-System 규칙을 사용해 프랙탈 나무를 생성하는 시뮬레이터입니다. 각도와 가지 길이, 바람 세기를 조절하며 세대별 성장을 관찰할 수 있습니다.

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <title>WebSim Samples</title>
   <style>
     table {border-collapse: collapse; width: 100%;}
-    th, td {border: 1px solid #ddd; padding: 8px;}
+    th, td {border: 1px solid #ddd; padding: 8px; text-align: center;}
     th {background-color: #f2f2f2;}
     a {color: #0366d6; text-decoration: none;}
     body {margin: 0;}
@@ -16,18 +16,18 @@
   <p>블로그 게시용 시뮬레이터 모음입니다. 아래 목록에서 각 데모와 설명을 확인할 수 있습니다.</p>
   <table>
     <thead>
-      <tr><th>번호</th><th>시뮬레이터</th><th>Demo</th><th>설명</th></tr>
+      <tr><th>번호</th><th>시뮬레이터</th><th>링크</th></tr>
     </thead>
     <tbody>
-      <tr><td>1</td><td><a href="https://prozac0401.tistory.com/37">개미 군집 최적화(ACO) 시뮬레이션</a></td><td><a href="aco_simulator/aco_simulator.html">demo</a></td><td><a href="aco_simulator/aco_simulator.md">설명</a></td></tr>
-      <tr><td>2</td><td><a href="https://prozac0401.tistory.com/34">보이드 알고리즘 새떼 시뮬레이션</a></td><td><a href="boids_simulation/boids_simulation.html">demo</a></td><td><a href="boids_simulation/boids_simulation.md">설명</a></td></tr>
-      <tr><td>3</td><td><a href="https://prozac0401.tistory.com/16">Conway의 Game of Life 구현</a></td><td><a href="conway-game-of-life/conway-game-of-life.html">demo</a></td><td><a href="conway-game-of-life/conway-game-of-life.md">설명</a></td></tr>
-      <tr><td>4</td><td><a href="https://prozac0401.tistory.com/56">행성 시뮬레이터</a></td><td><a href="cosmic-simulator-single-div/cosmic-simulator-single-div.html">demo</a></td><td><a href="cosmic-simulator-single-div/cosmic-simulator-single-div.md">설명</a></td></tr>
-      <tr><td>5</td><td><a href="https://prozac0401.tistory.com/43">중력 시뮬레이터 만들기</a></td><td><a href="gravity_simulator/gravity_simulator.html">demo</a></td><td><a href="gravity_simulator/gravity_simulator.md">설명</a></td></tr>
-      <tr><td>6</td><td><a href="https://prozac0401.tistory.com/35">Langton의 개미 시뮬레이터</a></td><td><a href="langtons_ant_simulator/langtons_ant_simulator.html">demo</a></td><td><a href="langtons_ant_simulator/langtons_ant_simulator.md">설명</a></td></tr>
-      <tr><td>7</td><td><a href="https://prozac0401.tistory.com/53">JavaScript QR 코드 생성기</a></td><td><a href="qr_generator/qr_generator.html">demo</a></td><td><a href="qr_generator/qr_generator.md">설명</a></td></tr>
-      <tr><td>8</td><td><a href="https://prozac0401.tistory.com/48">ulam_spiral 패턴 시각화</a></td><td><a href="ulam_spiral/ulam_spiral.html">demo</a></td><td><a href="ulam_spiral/ulam_spiral.md">설명</a></td></tr>
-      <tr><td>9</td><td><a href="https://prozac0401.tistory.com/61">프랙탈 나무 시뮬레이터</a></td><td><a href="fractal_tree_simulator/fractal_tree_simulator.html">demo</a></td><td><a href="fractal_tree_simulator/fractal_tree_simulator.md">설명</a></td></tr>
+      <tr><td>1</td><td><a href="https://prozac0401.tistory.com/37">개미 군집 최적화(ACO) 시뮬레이션</a></td><td><a href="aco_simulator/aco_simulator.html">보러가기</a> | <a href="aco_simulator/aco_simulator.md">설명</a></td></tr>
+      <tr><td>2</td><td><a href="https://prozac0401.tistory.com/34">보이드 알고리즘 새떼 시뮬레이션</a></td><td><a href="boids_simulation/boids_simulation.html">보러가기</a> | <a href="boids_simulation/boids_simulation.md">설명</a></td></tr>
+      <tr><td>3</td><td><a href="https://prozac0401.tistory.com/16">Conway의 Game of Life 구현</a></td><td><a href="conway-game-of-life/conway-game-of-life.html">보러가기</a> | <a href="conway-game-of-life/conway-game-of-life.md">설명</a></td></tr>
+      <tr><td>4</td><td><a href="https://prozac0401.tistory.com/56">행성 시뮬레이터</a></td><td><a href="cosmic-simulator-single-div/cosmic-simulator-single-div.html">보러가기</a> | <a href="cosmic-simulator-single-div/cosmic-simulator-single-div.md">설명</a></td></tr>
+      <tr><td>5</td><td><a href="https://prozac0401.tistory.com/43">중력 시뮬레이터 만들기</a></td><td><a href="gravity_simulator/gravity_simulator.html">보러가기</a> | <a href="gravity_simulator/gravity_simulator.md">설명</a></td></tr>
+      <tr><td>6</td><td><a href="https://prozac0401.tistory.com/35">Langton의 개미 시뮬레이터</a></td><td><a href="langtons_ant_simulator/langtons_ant_simulator.html">보러가기</a> | <a href="langtons_ant_simulator/langtons_ant_simulator.md">설명</a></td></tr>
+      <tr><td>7</td><td><a href="https://prozac0401.tistory.com/53">JavaScript QR 코드 생성기</a></td><td><a href="qr_generator/qr_generator.html">보러가기</a> | <a href="qr_generator/qr_generator.md">설명</a></td></tr>
+      <tr><td>8</td><td><a href="https://prozac0401.tistory.com/48">ulam_spiral 패턴 시각화</a></td><td><a href="ulam_spiral/ulam_spiral.html">보러가기</a> | <a href="ulam_spiral/ulam_spiral.md">설명</a></td></tr>
+      <tr><td>9</td><td>프랙탈 나무 시뮬레이터</td><td><a href="fractal_tree_simulator/fractal_tree_simulator.html">보러가기</a> | <a href="fractal_tree_simulator/fractal_tree_simulator.md">설명</a></td></tr>
     </tbody>
   </table>
 </body>


### PR DESCRIPTION
## Summary
- remove tistory link from fractal tree simulator docs
- combine demo & description columns in index.html and center align table
- update README entry for fractal tree simulator

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878d162e64c83209ff490ab2cd9de8e