### PR TITLE
Remove Pythagoras Tree and Barnsley Fern presets

### DIFF
--- a/fractal_tree_simulator/fractal_tree_simulator.html
+++ b/fractal_tree_simulator/fractal_tree_simulator.html
@@ -78,9 +78,7 @@
                     <option value="Levy C-Curve">Levy C-Curve</option>
                     <option value="Hilbert Curve">Hilbert Curve</option>
                     <option value="Gosper">Gosper</option>
-                    <option value="Pythagoras Tree">Pythagoras Tree</option>
                     <option value="Classic Fractal Plant">Classic Fractal Plant</option>
-                    <option value="Barnsley Fern">Barnsley Fern</option>
                     <option value="Penrose Tiling">Penrose Tiling</option>
                 </select>
             </label>
@@ -187,25 +185,9 @@
                     lenScale: 1,
                     maxLines: 500000
                 },
-                'Pythagoras Tree': {
-                    axiom: '0',
-                    rules: [{a:'1', b:'11'}, {a:'0', b:'1[0]0'}],
-                    angle: 45,
-                    start: -90,
-                    lenScale: 1,
-                    maxLines: 500000
-                },
                 'Classic Fractal Plant': {
                     axiom: 'X',
                     rules: [{a:'X', b:'F-[[X]+X]+F[+FX]-X'}, {a:'F', b:'FF'}],
-                    angle: 25,
-                    start: -90,
-                    lenScale: 0.67,
-                    maxLines: 500000
-                },
-                'Barnsley Fern': {
-                    axiom: 'X',
-                    rules: [{a:'X', b:'F+[[X]-X]-F[-FX]+X'}, {a:'F', b:'FF'}],
                     angle: 25,
                     start: -90,
                     lenScale: 0.67,


### PR DESCRIPTION
## Summary
- remove Pythagoras Tree and Barnsley Fern options
- delete corresponding pattern definitions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878ebacc0f08320b077eeab1156ac3d