### PR TITLE
Disable length slider for patterns that don't need it

### DIFF
--- a/fractal_tree_simulator/fractal_tree_simulator.html
+++ b/fractal_tree_simulator/fractal_tree_simulator.html
@@ -128,6 +128,16 @@
             let startAngleDeg = -90;
             const rules = [{a:'F', b:'FF-[-F+F+F]+[+F-F-F]'}];
 
+            const patternsRequireLen = new Set(['Fractal Tree', 'Classic Fractal Plant']);
+
+            function updateLenInputState(name){
+                if(patternsRequireLen.has(name)){
+                    lenInput.disabled = false;
+                }else{
+                    lenInput.disabled = true;
+                }
+            }
+
             const patterns = {
                 'Fractal Tree': {
                     axiom: 'F',
@@ -221,6 +231,7 @@
                 lineLimit = p.maxLines || 500000;
                 angleVal.textContent = angleDeg;
                 lenVal.textContent = lenScale;
+                updateLenInputState(name);
                 draw();
             }
 
@@ -368,7 +379,7 @@
                 draw();
             });
             patternSelect.addEventListener('change', function(){
-            resizeCanvas();
+                resizeCanvas();
                 applyPattern(patternSelect.value);
             });
 


### PR DESCRIPTION
## Summary
- disable length slider for patterns without adjustable length
- update fractal pattern apply logic to update slider state

## Testing
- `node -e "require('fs').readFileSync('fractal_tree_simulator/fractal_tree_simulator.html','utf8'); console.log('ok')"`


------
https://chatgpt.com/codex/tasks/task_e_68799e9a90808320a4c9e58786ee7302