### PR TITLE
Adjust sim max width

### DIFF
--- a/aco_simulator/aco_simulator.html
+++ b/aco_simulator/aco_simulator.html
@@ -14,8 +14,9 @@
         }
         
         .aco-simulator .container {
-            max-width: 100%;
-            margin: 0;
+            max-width: 800px;
+            width: 100%;
+            margin: 0 auto;
             padding: 10px;
         }
         
@@ -44,7 +45,8 @@
             display: block;
             margin: 0 auto;
             background-color: #fffef7;
-            max-width: 100%;
+            max-width: 800px;
+            width: 100%;
             height: auto;
             border: 1px solid #ddd;
             border-radius: 8px;

--- a/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
+++ b/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
@@ -17,9 +17,12 @@
     display: block;
     margin: 0 auto;
     background: #f8f9fa;
+    max-width: 800px;
+    width: 100%;
     }
     .controls {
-    max-width: 600px;
+    max-width: 800px;
+    width: 100%;
     margin: 10px auto;
     text-align: center;
     }
@@ -39,7 +42,7 @@
     <input id="nitrogenInterval" type="range" min="1" max="20" value="5" />
   </div>
   <div id="stats" style="text-align:center;margin-bottom:10px;">&nbsp;</div>
-  <div id="legend" style="max-width:600px;margin:0 auto 10px auto;font-size:14px;">
+  <div id="legend" style="max-width:800px;margin:0 auto 10px auto;font-size:14px;width:100%;">
     <span style="display:inline-block;width:12px;height:12px;background:#b5651d;vertical-align:middle;margin-right:4px;"></span>둥지
     <span style="display:inline-block;width:12px;height:12px;background:black;margin:0 0 0 10px;vertical-align:middle;margin-right:4px;"></span>개미
     <span style="display:inline-block;width:12px;height:12px;background:yellow;margin:0 0 0 10px;vertical-align:middle;margin-right:4px;border-radius:50%;"></span>질소 패치
@@ -196,7 +199,7 @@
     }
 
     function setup(){
-    CELL_SIZE = Math.floor(window.innerWidth/GRID_SIZE);
+    CELL_SIZE = Math.floor(Math.min(window.innerWidth, 800)/GRID_SIZE);
     WIDTH = CELL_SIZE * GRID_SIZE;
     HEIGHT = CELL_SIZE * GRID_HEIGHT;
     PLANT_THRESHOLD = CELL_SIZE/2;

--- a/langtons_ant_simulator/langtons_ant_simulator.html
+++ b/langtons_ant_simulator/langtons_ant_simulator.html
@@ -23,7 +23,7 @@
             
             .container {
                 width: 100%;
-                max-width: 1200px;
+                max-width: 800px;
                 text-align: center;
                 display: flex;
                 flex-direction: column;
@@ -166,7 +166,7 @@
             </div>
             
             <div class="canvas-container">
-                <canvas id="canvas" width="600" height="600"></canvas>
+                <canvas id="canvas" width="800" height="800" style="width:100%; max-width:800px; height:auto;"></canvas>
             </div>
             
             <div class="stats">
@@ -443,7 +443,7 @@
             function resizeCanvas() {
                 const container = document.querySelector('.canvas-container');
                 const availableWidth = Math.min(Math.max(window.innerWidth - 80, 100), 800);
-                const availableHeight = Math.min(Math.max(window.innerHeight - 300, 100), 600);
+                const availableHeight = Math.min(Math.max(window.innerHeight - 300, 100), 800);
                 const size = Math.max(Math.min(availableWidth, availableHeight), 100);
                 
                 canvas.width = size;

--- a/predator_prey_simulator/predator_prey_simulator.html
+++ b/predator_prey_simulator/predator_prey_simulator.html
@@ -15,10 +15,11 @@
   }
   .container {
     width: 100%;
+    max-width: 800px;
     margin: 0 auto;
     text-align: center;
   }
-  canvas { background: #f8f8f8; display: block; margin: 0 auto; }
+  canvas { background: #f8f8f8; display: block; margin: 0 auto; max-width: 800px; width: 100%; }
   #controls { margin-bottom: 10px; text-align:center; }
   #controls button { margin-right: 5px; }
   #sliders { margin: 10px 0; display: inline-block; text-align: left; }
@@ -70,7 +71,7 @@
       <span id="carnivoreDeathVal"></span>
     </div>
   </div>
-  <canvas id="sim" height="600" style="width:100%;"></canvas>
+  <canvas id="sim" height="600" style="width:100%; max-width:800px;"></canvas>
 </div>
 <script>
 (function() {


### PR DESCRIPTION
## Summary
- limit predator-prey simulator width to 800px
- cap Langton's ant simulator width at 800px
- restrict ant nitrogen cycle simulator width to 800px
- set ACO simulator container and canvas max width to 800px

## Testing
- `npm test` *(fails: could not find `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687a3454ab7083209da1ef7cf4a6193c