### PR TITLE
Improve add buttons behavior in predator prey simulator

### DIFF
--- a/predator_prey_simulator/predator_prey_simulator.html
+++ b/predator_prey_simulator/predator_prey_simulator.html
@@ -149,7 +149,6 @@
   const carnivores = [];
   const herbivoreEggs = [];
   const effects = [];
-  let addMode = null;
 
   class Plant {
     constructor(x, y) {
@@ -355,8 +354,12 @@
   document.getElementById('start-btn').onclick = () => running = true;
   document.getElementById('pause-btn').onclick = () => running = false;
   document.getElementById('reset-btn').onclick = () => { running = false; spawnInitial(); draw(); };
-  document.getElementById('add-herbivore-btn').onclick = () => { addMode = 'herbivore'; };
-  document.getElementById('add-carnivore-btn').onclick = () => { addMode = 'carnivore'; };
+  document.getElementById('add-herbivore-btn').onclick = () => {
+    herbivores.push(new Herbivore(randRange(0, canvas.width), randRange(0, canvas.height)));
+  };
+  document.getElementById('add-carnivore-btn').onclick = () => {
+    carnivores.push(new Carnivore(randRange(0, canvas.width), randRange(0, canvas.height)));
+  };
   fsBtn.addEventListener('click', () => {
     if (!document.fullscreenElement) {
       if (container.requestFullscreen) {
@@ -387,16 +390,6 @@
       canvas.style.height = '600px';
     }
     resizeCanvas();
-  });
-  canvas.addEventListener('click', e => {
-    if (addMode === 'herbivore') {
-      herbivores.push(new Herbivore(e.offsetX, e.offsetY));
-    } else if (addMode === 'carnivore') {
-      carnivores.push(new Carnivore(e.offsetX, e.offsetY));
-    } else {
-      return;
-    }
-    addMode = null;
   });
 
   spawnInitial();

--- a/predator_prey_simulator/predator_prey_simulator.md
+++ b/predator_prey_simulator/predator_prey_simulator.md
@@ -15,8 +15,8 @@
 - `carnivoreDeath` 육식동물 자연사 확률 (기본 0.001)
 
 ## 추가 기능
-상단의 "Add Herbivore", "Add Carnivore" 버튼을 누른 뒤 캔버스를 클릭하면
-해당 위치에 원하는 개체를 추가할 수 있습니다.
+상단의 "Add Herbivore", "Add Carnivore" 버튼을 누르면
+임의의 위치에 해당 개체가 즉시 생성됩니다.
 또한 "Fullscreen" 버튼으로 캔버스를 창 전체로 확대하거나 원래 크기로 되돌릴 수 있습니다.
 
 ## 슬라이더 조정


### PR DESCRIPTION
## Summary
- change Add Herbivore and Add Carnivore to immediately spawn creatures at random positions
- remove add-on-click mechanics
- update documentation to describe simplified behavior

## Testing
- `git diff --name-only`

------
https://chatgpt.com/codex/tasks/task_e_687a3c9dfbd08320a4de4e63b087537c