### PR TITLE
Improve predator prey fullscreen

### DIFF
--- a/predator_prey_simulator/predator_prey_simulator.html
+++ b/predator_prey_simulator/predator_prey_simulator.html
@@ -19,7 +19,7 @@
     margin: 0 auto;
     text-align: center;
   }
-  canvas { background: #f8f8f8; display: block; margin: 0 auto; max-width: 800px; width: 100%; }
+  canvas { background: #f8f8f8; display: block; margin: 0 auto; max-width: 800px; width: 100%; aspect-ratio: 1/1; }
   #controls { margin-bottom: 10px; text-align:center; }
   #controls button { margin-right: 5px; }
   #sliders { margin: 10px 0; display: inline-block; text-align: left; }
@@ -29,19 +29,7 @@
   .slider-group span { display: inline-block; width: 40px; text-align: right; }
 
   .container.fullscreen #controls {
-    position: absolute;
-    top: 10px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: rgba(255,255,255,0.7);
-    padding: 5px;
-    border-radius: 5px;
-    opacity: 0;
-    transition: opacity 0.3s;
-  }
-
-  .container.fullscreen #controls:hover {
-    opacity: 1;
+    display: none;
   }
 </style>
 </head>
@@ -87,7 +75,7 @@
       <span id="carnivoreDeathVal"></span>
     </div>
   </div>
-  <canvas id="sim" height="600" style="width:100%; max-width:800px;"></canvas>
+  <canvas id="sim" width="800" height="800" style="width:100%; max-width:800px; aspect-ratio:1/1;"></canvas>
 </div>
 <script>
 (function() {
@@ -365,16 +353,10 @@
       if (container.requestFullscreen) {
         container.requestFullscreen();
       }
-      canvas.style.height = '100vh';
-      canvas.style.width = '100vw';
-      container.classList.add('fullscreen');
     } else {
       if (document.exitFullscreen) {
         document.exitFullscreen();
       }
-      canvas.style.width = '100%';
-      canvas.style.height = '600px';
-      container.classList.remove('fullscreen');
     }
   });
   document.addEventListener('fullscreenchange', () => {
@@ -382,12 +364,12 @@
     fsBtn.textContent = inFs ? 'Exit Fullscreen' : 'Fullscreen';
     if (inFs) {
       container.classList.add('fullscreen');
-      canvas.style.height = '100vh';
       canvas.style.width = '100vw';
+      canvas.style.height = '100vh';
     } else {
       container.classList.remove('fullscreen');
-      canvas.style.width = '100%';
-      canvas.style.height = '600px';
+      canvas.style.width = '';
+      canvas.style.height = '';
     }
     resizeCanvas();
   });


### PR DESCRIPTION
## Summary
- hide controls entirely when fullscreen
- set canvas to keep a square shape using CSS `aspect-ratio`
- simplify fullscreen logic to let CSS handle canvas size on exit

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a3ef460c88320ab4eff078783f488