### PR TITLE
Fix predator-prey blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ https://prozac0401.github.io/WebSim
 - [JavaScript QR 코드 생성기](https://prozac0401.tistory.com/53) - [source](qr_generator/qr_generator.html) - [설명](qr_generator/qr_generator.md)
 - [ulam_spiral 패턴 시각화](https://prozac0401.tistory.com/48) - [source](ulam_spiral/ulam_spiral.html) - [설명](ulam_spiral/ulam_spiral.md)
 - [프랙탈 나무 시뮬레이터](https://prozac0401.tistory.com/66) - [source](fractal_tree_simulator/fractal_tree_simulator.html) - [설명](fractal_tree_simulator/fractal_tree_simulator.md)
-- [포식자-피식자 시뮬레이터](https://prozac0401.tistory.com/) - [source](predator_prey_simulator/predator_prey_simulator.html) - [설명](predator_prey_simulator/predator_prey_simulator.md)
+- [포식자-피식자 시뮬레이터](https://prozac0401.tistory.com/69) - [source](predator_prey_simulator/predator_prey_simulator.html) - [설명](predator_prey_simulator/predator_prey_simulator.md)
 - [개미-질소 순환 시뮬레이터](https://example.com/ant-nitrogen-sim) - [source](ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html) - [설명](ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.md)

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
        <tr><td>7</td><td><a href="https://prozac0401.tistory.com/53">JavaScript QR 코드 생성기</a></td><td><a href="qr_generator/qr_generator.html">보러가기</a> | <a href="qr_generator/qr_generator_doc.html">설명</a></td></tr>
        <tr><td>8</td><td><a href="https://prozac0401.tistory.com/48">ulam_spiral 패턴 시각화</a></td><td><a href="ulam_spiral/ulam_spiral.html">보러가기</a> | <a href="ulam_spiral/ulam_spiral_doc.html">설명</a></td></tr>
        <tr><td>9</td><td><a href="https://prozac0401.tistory.com/66">L-System 프랙탈 시뮬레이터</a></td><td><a href="fractal_tree_simulator/fractal_tree_simulator.html">보러가기</a> | <a href="fractal_tree_simulator/fractal_tree_simulator_doc.html">설명</a></td></tr>
-       <tr><td>10</td><td><a href="https://prozac0401.tistory.com/">포식자-피식자 시뮬레이터</a></td><td><a href="predator_prey_simulator/predator_prey_simulator.html">보러가기</a> | <a href="predator_prey_simulator/predator_prey_simulator_doc.html">설명</a></td></tr>
+       <tr><td>10</td><td><a href="https://prozac0401.tistory.com/69">포식자-피식자 시뮬레이터</a></td><td><a href="predator_prey_simulator/predator_prey_simulator.html">보러가기</a> | <a href="predator_prey_simulator/predator_prey_simulator_doc.html">설명</a></td></tr>
        <tr><td>11</td><td>개미-질소 순환 시뮬레이터</td><td><a href="ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html">보러가기</a> | <a href="ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator_doc.html">설명</a></td></tr>
     </tbody>
   </table>

--- a/predator_prey_simulator/predator_prey_simulator.md
+++ b/predator_prey_simulator/predator_prey_simulator.md
@@ -1,4 +1,6 @@
 # Predator-Prey Simulator
+[블로그 글]
+https://prozac0401.tistory.com/69
 
 간단한 포식자-피식자 생태계 모델을 웹에서 시각적으로 체험할 수 있는 데모입니다. URL 파라미터를 통해 초기 개체 수를 조정할 수 있으며 **Start**, **Pause**, **Reset** 버튼으로 시뮬레이션을 제어할 수 있습니다.
 


### PR DESCRIPTION
## Summary
- point README and index to the predator-prey blog post
- add blog link to predator prey doc

## Testing
- `git diff HEAD -- predator_prey_simulator/predator_prey_simulator.md`


------
https://chatgpt.com/codex/tasks/task_e_687a59a87ee48320885ca379231b8588