### PR TITLE
Update ant nitrogen simulator

### DIFF
--- a/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
+++ b/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
@@ -34,8 +34,8 @@
   <h1 style="text-align:center;">개미-질소 순환 시뮬레이터</h1>
   <p style="text-align:center;">개미가 유기물을 운반해 토양의 질소를 증가시키고 식물을 성장시키는 과정을 관찰해보세요.</p>
   <div class="controls">
-    <label>개미 수: <span id="antCountLabel">30</span></label>
-    <input id="antCount" type="range" min="10" max="100" value="30" />
+    <label>개미 수: <span id="antCountLabel">100</span></label>
+    <input id="antCount" type="range" min="10" max="100" value="100" />
     <br/>
     <label>질소량: <span id="nitrogenAmountLabel">50</span></label>
     <input id="nitrogenAmount" type="range" min="10" max="200" value="50" />
@@ -46,13 +46,13 @@
   <div id="stats" style="text-align:center;margin-bottom:10px;">&nbsp;</div>
   <div id="legend" style="max-width:800px;margin:0 auto 10px auto;font-size:14px;width:100%;">
     <span style="display:inline-block;width:12px;height:12px;background:#b5651d;vertical-align:middle;margin-right:4px;"></span>둥지
-    <span style="display:inline-block;width:12px;height:12px;background:black;margin:0 0 0 10px;vertical-align:middle;margin-right:4px;"></span>개미
-    <span style="display:inline-block;width:12px;height:12px;background:yellow;margin:0 0 0 10px;vertical-align:middle;margin-right:4px;border-radius:50%;"></span>질소 패치
+    <span style="display:inline-block;width:12px;height:12px;background:black;margin:0 0 0 10px;vertical-align:middle;margin-right:4px;border-radius:50%;"></span>개미
+    <span style="display:inline-block;width:12px;height:14px;background:yellow;margin:0 0 0 10px;vertical-align:middle;margin-right:4px;border-radius:50%/40%;"></span>질소 패치
     <span style="display:inline-block;width:12px;height:12px;background:rgb(50,150,50);margin:0 0 0 10px;vertical-align:middle;margin-right:4px;"></span>식물
   </div>
   <script>
     const GRID_SIZE = 20;
-    const GRID_HEIGHT = 30;
+    const GRID_HEIGHT = GRID_SIZE;
     let CELL_SIZE;
     let WIDTH;
     let HEIGHT;
@@ -141,8 +141,12 @@
     constructor(){
       this.pos = createVector(random(width), random(height));
       this.carrying = false;
+      this.isResting = false;
     }
     update(){
+      if(this.isResting){
+        return;
+      }
       if(this.carrying){
         let nestCell = getNearestNest(this.pos);
         let target = createVector(nestCell.x*CELL_SIZE+CELL_SIZE/2,
@@ -151,6 +155,7 @@
         if(p5.Vector.dist(this.pos,target)<5){
           nestCell.nitrogen += 5;
           this.carrying=false;
+          this.isResting=false;
         }
       }else{
         let nearest = null;
@@ -162,9 +167,15 @@
           }
         }
         if(nearest && dmin<5){
-          nearest.amount -= 5;
-          this.carrying=true;
+          if(nearest.amount>0){
+            nearest.amount -= 5;
+            this.carrying=true;
+            this.isResting=false;
+          } else {
+            this.isResting = true;
+          }
         }else if(nearest && dmin<80){
+          this.isResting = false;
           this.pos.add(p5.Vector.sub(nearest.pos,this.pos).setMag(1));
         }else{
           const cx = constrain(Math.floor(this.pos.x/CELL_SIZE),0,GRID_SIZE-1);
@@ -184,6 +195,7 @@
               }
             }
           }
+          this.isResting = false;
           this.pos.add(bestDir.setMag(1));
         }
       }
@@ -217,7 +229,7 @@
     }
     soil[NEST_X][NEST_Y].isNest = true;
     initFood();
-    initAnts(30);
+    initAnts(100);
     document.getElementById('antCount').addEventListener('input', e=>{
       const val = parseInt(e.target.value);
       document.getElementById('antCountLabel').textContent = val;
@@ -302,6 +314,10 @@ function relocateNest(cell){
   const cx = Math.floor(random(GRID_SIZE));
   const cy = Math.floor(random(HEIGHT/CELL_SIZE));
   foodSources.push(new FoodSource(cx*CELL_SIZE+CELL_SIZE/2, cy*CELL_SIZE+CELL_SIZE/2, nitrogenAmount));
+
+  for(let ant of ants){
+    ant.isResting = false;
+  }
 
     for(let dx=-1; dx<=1; dx++){
       for(let dy=-1; dy<=1; dy++){


### PR DESCRIPTION
## Summary
- equalize grid width/height for 1:1 aspect ratio
- increase default ant count to 100
- adjust legend icons to match canvas shapes
- allow ants to rest on empty patches and reset them when new nitrogen appears

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687a5d9a01548320962ff4516bd3ef37