### PR TITLE
Fix missing braces in ant nitrogen simulator

### DIFF
--- a/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
+++ b/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
@@ -384,6 +384,7 @@
     }
 
     function setup(){
+    console.log('setup called');
     const size = Math.min(window.innerWidth, 900);
     CELL_SIZE = Math.floor(size / GRID_SIZE);
     WIDTH = CELL_SIZE * GRID_SIZE;
@@ -506,6 +507,7 @@ function spawnNitrogenPatch(){
         let nx=cx+dx, ny=cy+dy;
         if(nx>=0 && nx<GRID_SIZE && ny>=0 && ny<HEIGHT/CELL_SIZE){
           soil[nx][ny].nitrogen += nitrogenAmount/3;
+        }
     }
   }
 }
@@ -556,5 +558,7 @@ function updateFoodSources(){
       soil[NEST_X][NEST_Y].isNest=true;
       loop();
     });
+    console.log('setup type before new p5', typeof window.setup);
+    new p5();
   </script>
 </div>


### PR DESCRIPTION
## Summary
- close missing braces in `spawnNitrogenPatch`
- ensure inner conditional closes before `else`
- log setup type before running p5

## Testing
- `node - <<'NODE'
const esprima=require('esprima');
const fs=require('fs');
const html=fs.readFileSync('ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html','utf8');
const script=html.slice(html.lastIndexOf('<script>')+8, html.lastIndexOf('</script>'));
esprima.parseScript(script);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_687af12a9fa88320a1c8afb60cf5bb7d