### PR TITLE
Fix deterministic ant sim by removing global randomSeed

### DIFF
--- a/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
+++ b/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
@@ -78,6 +78,15 @@
     const TREE_LIFESPAN = 800;
     let clusterCenters = [];
 
+    function mulberry32(a){
+      return function(){
+        var t = a += 0x6D2B79F5;
+        t = Math.imul(t ^ t >>> 15, t | 1);
+        t ^= t + Math.imul(t ^ t >>> 7, t | 61);
+        return ((t ^ t >>> 14) >>> 0) / 4294967296;
+      }
+    }
+
     class SoilCell {
     constructor(x, y) {
       this.x = x; this.y = y;
@@ -337,14 +346,15 @@
       strokeWeight(6);
       line(0,0,0,-h);
       noStroke();
-      randomSeed(x*1000+y);
+      const rng = mulberry32(x*1000+y);
       for(let i=0;i<30;i++){
-        const ang = random(TWO_PI);
-        const rad = random(h*0.1, h*0.8);
+        const ang = rng()*TWO_PI;
+        const rad = rng()*(h*0.7) + h*0.1;
         const sx = cos(ang)*rad;
         const sy = -h + sin(ang)*rad*0.5;
-        const size = random(h*0.15, h*0.3);
-        const col = random(['#ffc6dc','#ffd9e8','#ffeef5']);
+        const size = rng()*(h*0.15) + h*0.15;
+        const colors = ['#ffc6dc','#ffd9e8','#ffeef5'];
+        const col = colors[Math.floor(rng()*colors.length)];
         stroke(col);
         strokeWeight(1);
         noFill();
@@ -361,14 +371,15 @@
       strokeWeight(8);
       line(0,0,0,-size);
       noStroke();
-      randomSeed(cx*2000+cy);
+      const rng = mulberry32(cx*2000+cy);
       for(let i=0;i<70;i++){
-        const ang = random(TWO_PI);
-        const rad = random(size*0.2,size*1.2);
+        const ang = rng()*TWO_PI;
+        const rad = rng()*size*1.0 + size*0.2;
         const sx = cos(ang)*rad;
         const sy = -size + sin(ang)*rad*0.6;
-        const rsize = random(size*0.25,size*0.4);
-        const col = random(['#ffc6dc','#ffd9e8','#ffeef5']);
+        const rsize = rng()*size*0.15 + size*0.25;
+        const colors = ['#ffc6dc','#ffd9e8','#ffeef5'];
+        const col = colors[Math.floor(rng()*colors.length)];
         stroke(col);
         strokeWeight(1);
         noFill();


### PR DESCRIPTION
## Summary
- use a local PRNG instead of p5's `randomSeed` for drawing trees
- add `mulberry32` helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687aff35401c83208eedc85a0f469789