### PR TITLE
Fix pheromone follow and cherry blossom storm

### DIFF
--- a/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
+++ b/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
@@ -78,6 +78,15 @@
     const TREE_LIFESPAN = 800;
     let clusterCenters = [];
 
+    function mulberry32(a){
+      return function(){
+        var t = a += 0x6D2B79F5;
+        t = Math.imul(t ^ t >>> 15, t | 1);
+        t ^= t + Math.imul(t ^ t >>> 7, t | 61);
+        return ((t ^ t >>> 14) >>> 0) / 4294967296;
+      }
+    }
+
     class SoilCell {
     constructor(x, y) {
       this.x = x; this.y = y;
@@ -211,13 +220,30 @@
     }
     update(){
       const prev = this.pos.copy();
-      if(this.isResting){
-        return;
-      }
-
       const cx = constrain(Math.floor(this.pos.x/CELL_SIZE),0,GRID_SIZE-1);
       const cy = constrain(Math.floor(this.pos.y/CELL_SIZE),0,HEIGHT/CELL_SIZE-1);
       const cell = soil[cx][cy];
+
+      if(this.isResting){
+        let awakened = cell.pheromone > 0.1;
+        for(let dx=-1; dx<=1 && !awakened; dx++){
+          for(let dy=-1; dy<=1 && !awakened; dy++){
+            if(dx===0 && dy===0) continue;
+            let nx=cx+dx, ny=cy+dy;
+            if(nx>=0 && nx<GRID_SIZE && ny>=0 && ny<HEIGHT/CELL_SIZE){
+              if(soil[nx][ny].pheromone > 0.1){
+                this.pos.add(createVector(dx,dy).setMag(ANT_SPEED));
+                this.dir = dx==1?1:dx==-1?3:dy==1?2:0;
+                awakened = true;
+              }
+            }
+          }
+        }
+        if(!awakened){
+          return;
+        }
+        this.isResting=false;
+      }
 
       if(cell.plant > 1){
         this.pos = prev;
@@ -337,14 +363,15 @@
       strokeWeight(6);
       line(0,0,0,-h);
       noStroke();
-      randomSeed(x*1000+y);
-      for(let i=0;i<30;i++){
-        const ang = random(TWO_PI);
-        const rad = random(h*0.1, h*0.8);
+      const rng = mulberry32(x*1000+y);
+      for(let i=0;i<20;i++){ 
+        const ang = rng()*TWO_PI; 
+        const rad = rng()*(h*0.6) + h*0.2; 
         const sx = cos(ang)*rad;
         const sy = -h + sin(ang)*rad*0.5;
-        const size = random(h*0.15, h*0.3);
-        const col = random(['#ffc6dc','#ffd9e8','#ffeef5']);
+        const size = rng()*(h*0.15) + h*0.15;
+        const colors = ['#ffc6dc','#ffd9e8','#ffeef5'];
+        const col = colors[Math.floor(rng()*colors.length)];
         stroke(col);
         strokeWeight(1);
         noFill();
@@ -361,14 +388,15 @@
       strokeWeight(8);
       line(0,0,0,-size);
       noStroke();
-      randomSeed(cx*2000+cy);
-      for(let i=0;i<70;i++){
-        const ang = random(TWO_PI);
-        const rad = random(size*0.2,size*1.2);
+      const rng = mulberry32(cx*2000+cy);
+      for(let i=0;i<50;i++){ 
+        const ang = rng()*TWO_PI; 
+        const rad = rng()*size*0.8 + size*0.2; 
         const sx = cos(ang)*rad;
         const sy = -size + sin(ang)*rad*0.6;
-        const rsize = random(size*0.25,size*0.4);
-        const col = random(['#ffc6dc','#ffd9e8','#ffeef5']);
+        const rsize = rng()*size*0.15 + size*0.25;
+        const colors = ['#ffc6dc','#ffd9e8','#ffeef5'];
+        const col = colors[Math.floor(rng()*colors.length)];
         stroke(col);
         strokeWeight(1);
         noFill();
@@ -390,15 +418,32 @@
 
     function computeClusterCenters(){
       clusterCenters = [];
-      for(let x=1; x<GRID_SIZE-1; x++){
-        for(let y=1; y<HEIGHT/CELL_SIZE-1; y++){
-          let all=true;
-          for(let dx=-1; dx<=1 && all; dx++){
-            for(let dy=-1; dy<=1; dy++){
-              if(soil[x+dx][y+dy].plant <= 1){ all=false; break; }
+      const visited = Array.from({length: GRID_SIZE}, () =>
+        Array(HEIGHT/CELL_SIZE).fill(false));
+      for(let x=0; x<GRID_SIZE; x++){
+        for(let y=0; y<HEIGHT/CELL_SIZE; y++){
+          if(visited[x][y] || soil[x][y].plant <= 1) continue;
+          const queue = [[x,y]];
+          visited[x][y] = true;
+          let sumX = 0, sumY = 0, count = 0;
+          while(queue.length){
+            const [cx,cy] = queue.pop();
+            sumX += cx; sumY += cy; count++;
+            for(let dx=-1; dx<=1; dx++){
+              for(let dy=-1; dy<=1; dy++){
+                if(dx===0 && dy===0) continue;
+                let nx=cx+dx, ny=cy+dy;
+                if(nx>=0 && nx<GRID_SIZE && ny>=0 && ny<HEIGHT/CELL_SIZE &&
+                   !visited[nx][ny] && soil[nx][ny].plant > 1){
+                  visited[nx][ny] = true;
+                  queue.push([nx,ny]);
+                }
+              }
             }
           }
-          if(all) clusterCenters.push({x,y});
+          if(count >= 9){
+            clusterCenters.push({x: Math.round(sumX/count), y: Math.round(sumY/count)});
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- let resting ants follow nearby pheromones
- shrink cherry blossom clusters to avoid canvas takeover
- detect tree clusters with BFS so only one tree is drawn per cluster

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687aff35401c83208eedc85a0f469789