### PR TITLE
Fix cluster center bounds in ant simulator

### DIFF
--- a/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
+++ b/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
@@ -442,7 +442,11 @@
             }
           }
           if(count >= 9){
-            clusterCenters.push({x: Math.round(sumX/count), y: Math.round(sumY/count)});
+            let cx = Math.floor(sumX / count);
+            let cy = Math.floor(sumY / count);
+            cx = constrain(cx, 0, GRID_SIZE - 1);
+            cy = constrain(cy, 0, HEIGHT / CELL_SIZE - 1);
+            clusterCenters.push({x: cx, y: cy});
           }
         }
       }


### PR DESCRIPTION
## Summary
- fix rounding when computing cluster centers for the ant-nitrogen cycle simulator
- ensure centers stay within grid bounds

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687b08e1b2e08320ae80b254f960910f