### PR TITLE
Show nutrient path from nest

### DIFF
--- a/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
+++ b/ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html
@@ -81,6 +81,7 @@
     const MIN_CLUSTER_SIZE = 5; // cells needed to form a big tree
     let nestCount = 0;
     let clusterCenters = [];
+    let flowPath = [];
 
     function mulberry32(a){
       return function(){
@@ -161,7 +162,7 @@
         fill(180,80,200,alpha);
         rect(this.x*CELL_SIZE, this.y*CELL_SIZE, CELL_SIZE, CELL_SIZE);
       }
-        if(this.nitrogen>0.5 && !this.isNest && this.plant <= 1){
+      if(this.nitrogen>0.5 && !this.isNest && this.plant <= 1){
           fill('#ffb6c1');
           noStroke();
           ellipse(this.x*CELL_SIZE+CELL_SIZE/2, this.y*CELL_SIZE+CELL_SIZE/2, CELL_SIZE*0.3, CELL_SIZE*0.3);
@@ -169,6 +170,37 @@
         if(this.isNest){
           fill('#b5651d');
           rect(this.x*CELL_SIZE, this.y*CELL_SIZE, CELL_SIZE, CELL_SIZE);
+        }
+      }
+      displayNitrogenFlow(){
+        if(this.isNest || this.plant>1) return;
+        textAlign(CENTER, CENTER);
+        textSize(CELL_SIZE*0.5);
+        noStroke();
+        const dirs=[
+          {dx:0,dy:-1,ch:'▼'}, // from cell above to here
+          {dx:1,dy:0,ch:'◀'},  // from cell to the right
+          {dx:0,dy:1,ch:'▲'},  // from cell below
+          {dx:-1,dy:0,ch:'▶'}  // from cell to the left
+        ];
+        let bestDiff=0;
+        let arrow=null;
+        for(let d of dirs){
+          const nx=this.x+d.dx;
+          const ny=this.y+d.dy;
+          if(nx>=0 && nx<GRID_SIZE && ny>=0 && ny<HEIGHT/CELL_SIZE){
+            const diff=soil[nx][ny].nitrogen-this.nitrogen;
+            if(diff>0.05 && diff>bestDiff){
+              bestDiff=diff;
+              arrow=d.ch;
+            }
+          }
+        }
+        if(arrow){
+          const c=color('#ff9900');
+          c.setAlpha(constrain(bestDiff*80,50,200));
+          fill(c);
+          text(arrow, this.x*CELL_SIZE+CELL_SIZE/2, this.y*CELL_SIZE+CELL_SIZE/2);
         }
       }
       displayPlant(){
@@ -439,7 +471,7 @@
         pop();
       }
 
-    function computeClusterCenters(){
+function computeClusterCenters(){
       clusterCenters = [];
       const visited = Array.from({length: GRID_SIZE}, () =>
         Array(HEIGHT/CELL_SIZE).fill(false));
@@ -540,14 +572,23 @@
       releaseTrappedAnts(NEST_X, NEST_Y);
     }
     computeClusterCenters();
-    for(let c of clusterCenters){
-      drawBigCherryTree(c.x,c.y);
-    }
-    for(let x=0;x<GRID_SIZE;x++){
-      for(let y=0;y<HEIGHT/CELL_SIZE;y++){
-        if(!isPartOfCluster(x,y)) soil[x][y].displayPlant();
+    computeFlowPath();
+      for(let c of clusterCenters){
+        drawBigCherryTree(c.x,c.y);
       }
-    }
+      for(let x=0;x<GRID_SIZE;x++){
+        for(let y=0;y<HEIGHT/CELL_SIZE;y++){
+          if(!isPartOfCluster(x,y)) soil[x][y].displayPlant();
+        }
+      }
+    drawFlowPath();
+
+      // draw nitrogen arrows on top of trees and plants so flow remains visible
+      for(let x=0;x<GRID_SIZE;x++){
+        for(let y=0;y<HEIGHT/CELL_SIZE;y++){
+          soil[x][y].displayNitrogenFlow();
+        }
+      }
 
     }
 
@@ -715,6 +756,51 @@ function spawnNitrogenPatchAround(cx, cy){
         }
       }
     }
+  }
+}
+
+function computeFlowPath(){
+  flowPath = [];
+  const DIRS = [
+    {dx:0,dy:-1,ch:'▲'},
+    {dx:1,dy:0,ch:'▶'},
+    {dx:0,dy:1,ch:'▼'},
+    {dx:-1,dy:0,ch:'◀'}
+  ];
+  let cx = NEST_X;
+  let cy = NEST_Y;
+  const visited = new Set([cx+','+cy]);
+  for(let i=0;i<GRID_SIZE*2;i++){
+    let best = null;
+    let bestVal = soil[cx][cy].plant*2 + soil[cx][cy].nitrogen;
+    let bestDir = null;
+    for(let d of DIRS){
+      const nx=cx+d.dx, ny=cy+d.dy;
+      if(nx>=0 && nx<GRID_SIZE && ny>=0 && ny<HEIGHT/CELL_SIZE && !visited.has(nx+','+ny)){
+        const cell=soil[nx][ny];
+        const val=cell.plant*2 + cell.nitrogen;
+        if(val>bestVal){
+          bestVal=val;
+          best={x:nx,y:ny};
+          bestDir=d.ch;
+        }
+      }
+    }
+    if(!best) break;
+    flowPath.push({x:cx,y:cy,ch:bestDir});
+    cx=best.x; cy=best.y;
+    visited.add(cx+','+cy);
+    if(soil[cx][cy].plant>1) break;
+  }
+}
+
+function drawFlowPath(){
+  textAlign(CENTER,CENTER);
+  textSize(CELL_SIZE*0.6);
+  noStroke();
+  fill('#ff6600');
+  for(let step of flowPath){
+    text(step.ch, step.x*CELL_SIZE+CELL_SIZE/2, step.y*CELL_SIZE+CELL_SIZE/2);
   }
 }
 


### PR DESCRIPTION
## Summary
- lower nitrogen arrow threshold
- compute a main flow path from the nest toward high nutrient cells
- draw this path over the grid so upcoming tree locations are hinted

## Testing
- `node -e "require('fs').readFileSync('ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html','utf8')" >/dev/null && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_687b26d937708320a7ddab3e1290d200