### PR TITLE
Add DLA simulator to README and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ https://prozac0401.github.io/WebSim
 - [프랙탈 나무 시뮬레이터](https://prozac0401.tistory.com/66) - [source](fractal_tree_simulator/fractal_tree_simulator.html) - [설명](fractal_tree_simulator/fractal_tree_simulator.md)
 - [포식자-피식자 시뮬레이터](https://prozac0401.tistory.com/69) - [source](predator_prey_simulator/predator_prey_simulator.html) - [설명](predator_prey_simulator/predator_prey_simulator.md)
 - [개미-질소 순환 시뮬레이터](미개시) - [source](ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html) - [설명](ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.md)
+- [확산-제한 응집(DLA) 시뮬레이터](미개시) - [source](dla_simulator/standalone.html) - [설명](dla_simulator/README.md)

--- a/dla_simulator/dla_simulator_doc.html
+++ b/dla_simulator/dla_simulator_doc.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <!-- 최신 Marked 16.x CDN -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module">
+    const md = await fetch('README.md').then(r => r.text());
+    document.getElementById('app').innerHTML = marked.parse(md);
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
        <tr><td>9</td><td><a href="https://prozac0401.tistory.com/66">L-System 프랙탈 시뮬레이터</a></td><td><a href="fractal_tree_simulator/fractal_tree_simulator.html">보러가기</a> | <a href="fractal_tree_simulator/fractal_tree_simulator_doc.html">설명</a></td></tr>
        <tr><td>10</td><td><a href="https://prozac0401.tistory.com/69">포식자-피식자 시뮬레이터</a></td><td><a href="predator_prey_simulator/predator_prey_simulator.html">보러가기</a> | <a href="predator_prey_simulator/predator_prey_simulator_doc.html">설명</a></td></tr>
        <tr><td>11</td><td>(미개시) 개미-영양분 순환 시뮬레이터</td><td><a href="ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html">보러가기</a> | <a href="ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator_doc.html">설명</a></td></tr>
+       <tr><td>12</td><td>(미개시) DLA 시뮬레이터</td><td><a href="dla_simulator/standalone.html">보러가기</a> | <a href="dla_simulator/dla_simulator_doc.html">설명</a></td></tr>
     </tbody>
   </table>
 </body>


### PR DESCRIPTION
## Summary
- Document Diffusion-Limited Aggregation (DLA) simulator in README.
- Add DLA simulator to site index with link to demo and docs.
- Provide HTML doc page that renders the simulator README.

## Testing
- `cd dla_simulator && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895ab0f8c988320a753410591b65d48