### PR TITLE
chore: remove DLA simulator from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,3 @@ https://prozac0401.github.io/WebSim
 - [프랙탈 나무 시뮬레이터](https://prozac0401.tistory.com/66) - [source](fractal_tree_simulator/fractal_tree_simulator.html) - [설명](fractal_tree_simulator/fractal_tree_simulator.md)
 - [포식자-피식자 시뮬레이터](https://prozac0401.tistory.com/69) - [source](predator_prey_simulator/predator_prey_simulator.html) - [설명](predator_prey_simulator/predator_prey_simulator.md)
 - [개미-질소 순환 시뮬레이터](미개시) - [source](ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.html) - [설명](ant_nitrogen_cycle_simulator/ant_nitrogen_cycle_simulator.md)
-- [확산-제한 응집(DLA) 시뮬레이터](미개시) - [source](dla_simulator/standalone.html) - [설명](dla_simulator/README.md)


### PR DESCRIPTION
## Summary
- remove DLA simulator from README list

## Testing
- `npm test` (fails: could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6896c07a01f48320862a3a8e04da2c86